### PR TITLE
Disable when DISABLE_VIEW_SOURCE_MAP is given as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ $ rails s
 then see the source of your page:
 
 ![](http://dl.dropbox.com/u/5978869/image/20121204_171625.png)
+
+## Tips
+Sometimes this adds too much noise to the html when you're developing.  
+There is a simple way to turn it off.
+
+```
+$ DISABLE_VIEW_SOURCE_MAP=1 rails s
+```

--- a/lib/view_source_map.rb
+++ b/lib/view_source_map.rb
@@ -1,7 +1,9 @@
 module ViewSourceMap
   class Railtie < Rails::Railtie
     initializer "render_with_path_comment.initialize" do
-      ViewSourceMap.attach if Rails.env.development?
+      if !ENV["DISABLE_VIEW_SOURCE_MAP"] && Rails.env.development?
+        ViewSourceMap.attach
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes this gem adds too much noise to the html when you're developing.
There is a simple way to turn it off.

```
$ DISABLE_VIEW_SOURCE_MAP=1 rails s
```
