### PR TITLE
Put newline after begin

### DIFF
--- a/lib/view_source_map.rb
+++ b/lib/view_source_map.rb
@@ -19,7 +19,7 @@ module ViewSourceMap
             path = Pathname.new(@template.identifier)
             name = path.relative_path_from(Rails.root)
           end
-          "<!-- BEGIN #{name} -->#{content}<!-- END #{name} -->".html_safe
+          "<!-- BEGIN #{name} -->\n#{content}<!-- END #{name} -->".html_safe
         else
           content
         end
@@ -37,7 +37,7 @@ module ViewSourceMap
             if @lookup_context.rendered_format == :html and template.class != ActionView::Template::Text
               path = Pathname.new(template.identifier)
               name = path.relative_path_from(Rails.root)
-              "<!-- BEGIN #{name} -->#{content}<!-- END #{name} -->".html_safe
+              "<!-- BEGIN #{name} -->\n#{content}<!-- END #{name} -->".html_safe
             else
               content
             end


### PR DESCRIPTION
Rendering `.js.erb` into `.html` will cause syntax errors of JavaScript.

![Example](https://cloud.githubusercontent.com/assets/139089/3810774/24b73296-1c95-11e4-8747-58d2ec893e10.png)

The HTML comment token tells web browser to skip the first line of the following JS program here.

Inserting newline after `<!-- BEGIN ... -->` solves this issue.
