### PR TITLE
Fix link to gem version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ViewSourceMap
 
-[![Gem](https://img.shields.io/gem/v/formatador.svg)](https://rubygems.org/gems/view_source_map)
+[![Gem](https://img.shields.io/gem/v/view_source_map.svg)](https://rubygems.org/gems/view_source_map)
 [![Build Status](https://travis-ci.org/r7kamura/view_source_map.svg?branch=master)](https://travis-ci.org/r7kamura/view_source_map)
 
 This is a Rails plugin to insert the path name of a rendered partial view as HTML comment in development environment.


### PR DESCRIPTION
Before: This is the version of **formatador**.
![2016-12-06 16 41 09](https://cloud.githubusercontent.com/assets/290782/20917092/d9c97426-bbd2-11e6-8bc3-f5aff298b715.png)

After: This is the version of **view_source_map**.

![2016-12-06 16 41 23](https://cloud.githubusercontent.com/assets/290782/20917094/db615d4e-bbd2-11e6-8803-da2eb4bb3667.png)
