### PR TITLE
Rescue from irregular template

### DIFF
--- a/lib/view_source_map.rb
+++ b/lib/view_source_map.rb
@@ -40,8 +40,9 @@ module ViewSourceMap
             content = template.render(view, locals) { |*name| view._layout_for(*name) }
             return content if ViewSourceMap.force_disabled?(locals)
 
-            if @lookup_context.rendered_format == :html && template.class != ActionView::Template::Text && !template.identifier.to_s.empty?
-              path = Pathname.new(template.identifier)
+            path = Pathname.new(template.identifier)
+
+            if @lookup_context.rendered_format == :html && path.file?
               name = path.relative_path_from(Rails.root)
               "<!-- BEGIN #{name} -->\n#{content}<!-- END #{name} -->".html_safe
             else


### PR DESCRIPTION
@r7kamura ありがとうございます。

詳細見てみました。
以下のように`html template`という文字列が`template`には入っています。

```
    35: def render_template_with_path_comment(template, layout_name = nil, locals = {})
    36:   view, locals = @view, locals || {}
    37: 
    38:   render_with_layout(layout_name, locals) do |layout|
    39:     instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
    40:       content = template.render(view, locals) { |*name| view._layout_for(*name) }
    41:       return content if ViewSourceMap.force_disabled?(locals)
    42: 
    43:       binding.pry
 => 44:       if @lookup_context.rendered_format == :html && template.class != ActionView::Template::Text && template.identifier.present?
    45:         path = Pathname.new(template.identifier)
    46:         name = path.relative_path_from(Rails.root)
    47:         "<!-- BEGIN #{name} -->\n#{content}<!-- END #{name} -->".html_safe
    48:       else
    49:         content
    50:       end
    51:     end
    52:   end
    53: end

5.0.2@2.4.0 (#<ActionView::TemplateRenderer:0x007fcdd7e40618>)> template.identifier
=> "html template"
5.0.2@2.4.0 (#<ActionView::TemplateRenderer:0x007fcdd7e40618>)> quit
  Rendered html template (5434.6ms)
Completed 500 Internal Server Error in 5503ms (ActiveRecord: 0.0ms)

```

`letter_opener_web`がどのようにrenderしているかをみてみました。

```
def show
      text = @letter.send("#{params[:style]}_text")
                    .gsub(/"plain\.html"/, "\"#{routes.letter_path(id: @letter.id, style: 'plain')}\"")
                    .gsub(/"rich\.html"/, "\"#{routes.letter_path(id: @letter.id, style: 'rich')}\"")

      render html: text.html_safe
    end
```

このようなケースでは、issueに貼った他の事例のようにrescueすればいいでしょうか。
変更をＰRさせて頂きます。

<img width="536" alt="letteropenerweb" src="https://cloud.githubusercontent.com/assets/2703486/23601129/3e9a020c-028d-11e7-8f55-4137d47b1e19.png">

通常の表示は従来通りでした。