### PR TITLE
Test on Ruby 2.4 & Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ matrix:
       env: RAILS_VERSION="~> 5.0.0"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.0.0"
-    - rvm: 2.4.1
-      env: RAILS_VERSION="~> 4.2.0"


### PR DESCRIPTION
Now json gem 1.8.6 that works with Ruby 2.4.0 is released.
No longer there is no reason to skip these combination.