### PR TITLE
Support Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - RAILS_VERSION="~> 5.0.0"
     - RAILS_VERSION="~> 5.1.0"
     - RAILS_VERSION="~> 5.2.0"
+    - RAILS_VERSION="~> 6.0.0"
 matrix:
   exclude:
     - rvm: 2.0.0
@@ -28,9 +29,19 @@ matrix:
       env: RAILS_VERSION="~> 5.1.0"
     - rvm: 2.0.0
       env: RAILS_VERSION="~> 5.2.0"
+    - rvm: 2.0.0
+      env: RAILS_VERSION="~> 6.0.0"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.0.0"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.1.0"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.2.0"
+    - rvm: 2.1.10
+      env: RAILS_VERSION="~> 6.0.0"
+    - rvm: 2.2.10
+      env: RAILS_VERSION="~> 6.0.0"
+    - rvm: 2.3.8
+      env: RAILS_VERSION="~> 6.0.0"
+    - rvm: 2.4.5
+      env: RAILS_VERSION="~> 6.0.0"

--- a/lib/view_source_map.rb
+++ b/lib/view_source_map.rb
@@ -15,15 +15,10 @@ module ViewSourceMap
         content = render_without_path_comment(context, options, block)
         return content if ViewSourceMap.force_disabled?(options)
 
-        if @lookup_context.rendered_format == :html
-          if options[:layout]
-            name = "#{options[:layout]}(layout)"
-          else
-            return content unless @template.respond_to?(:identifier)
-            path = Pathname.new(@template.identifier)
-            name = path.relative_path_from(Rails.root)
-          end
-          "<!-- BEGIN #{name} -->\n#{content}<!-- END #{name} -->".html_safe
+        if @lookup_context.formats.first == :html
+          name = ViewSourceMap.find_name(content, options)
+          return content unless name
+          ViewSourceMap.update_content_with_comment!(content, name)
         else
           content
         end
@@ -32,18 +27,17 @@ module ViewSourceMap
       alias_method :render, :render_with_path_comment
     end
 
-    ActionView::TemplateRenderer.class_eval do
-      def render_template_with_path_comment(template, layout_name = nil, locals = {})
-        view, locals = @view, locals || {}
 
-        render_with_layout(layout_name, locals) do |layout|
-          instrument(:template, :identifier => template.identifier, :layout => layout.try(:virtual_path)) do
+    ActionView::TemplateRenderer.class_eval do
+      def render_template_with_path_comment(view, template, layout_name, locals)
+        render_with_layout(view, template, layout_name, locals) do |layout|
+          instrument(:template, identifier: template.identifier, layout: layout.try(:virtual_path)) do
             content = template.render(view, locals) { |*name| view._layout_for(*name) }
             return content if ViewSourceMap.force_disabled?(locals)
 
             path = Pathname.new(template.identifier)
 
-            if @lookup_context.rendered_format == :html && path.file?
+            if @lookup_context.formats.first == :html && path.file?
               name = path.relative_path_from(Rails.root)
               "<!-- BEGIN #{name} -->\n#{content}<!-- END #{name} -->".html_safe
             else
@@ -69,6 +63,32 @@ module ViewSourceMap
       undef_method :render_template_with_path_comment
       alias_method :render_template, :render_template_without_path_comment
     end
+  end
+
+  def self.find_name(content, options)
+    return "#{options[:layout]}(layout)" if options[:layout]
+
+    template = if content.is_a?(ActionView::AbstractRenderer::RenderedCollection)
+                 content.rendered_templates.first.template
+               elsif content.is_a?(ActionView::AbstractRenderer::RenderedTemplate)
+                 content.template
+               end
+
+    return nil unless template.respond_to?(:identifier)
+    path = Pathname.new(template.identifier)
+    path.relative_path_from(Rails.root)
+  end
+
+  def self.update_content_with_comment!(content, name)
+    if content.is_a?(ActionView::AbstractRenderer::RenderedCollection)
+      content.instance_eval do
+        @rendered_templates.first.instance_eval { @body = "<!-- BEGIN #{name} -->\n#{@body}".html_safe }
+        @rendered_templates.last.instance_eval { @body = "#{@body}<!-- END #{name} -->".html_safe }
+      end
+    elsif content.is_a?(ActionView::AbstractRenderer::RenderedTemplate)
+      content.instance_eval { @body = "<!-- BEGIN #{name} -->\n#{@body}<!-- END #{name} -->".html_safe }
+    end
+    content
   end
 
   def self.force_disabled?(options)

--- a/spec/controllers/examples_controller_spec.rb
+++ b/spec/controllers/examples_controller_spec.rb
@@ -13,7 +13,7 @@ describe ExamplesController do
         end
 
         it "does not show partial view's relative path as HTML comment" do
-          should be_success
+          should be_successful
           response.body.should_not include("<!-- BEGIN app/views/examples/_example.html.erb -->")
           response.body.should_not include("<!-- END app/views/examples/_example.html.erb -->")
           response.body.should_not include("<!-- BEGIN app/views/examples/index.html.erb -->")
@@ -27,9 +27,11 @@ describe ExamplesController do
         end
 
         it "shows partial view's relative path as HTML comment" do
-          should be_success
+          should be_successful
           response.body.should include("<!-- BEGIN app/views/examples/_example.html.erb -->")
           response.body.should include("<!-- END app/views/examples/_example.html.erb -->")
+          response.body.should include("<!-- BEGIN app/views/examples/_example_collection_item.html.erb -->")
+          response.body.should include("<!-- END app/views/examples/_example_collection_item.html.erb -->")
           response.body.should include("<!-- BEGIN app/views/examples/index.html.erb -->")
           response.body.should include("<!-- END app/views/examples/index.html.erb -->")
         end
@@ -46,7 +48,7 @@ describe ExamplesController do
         end
 
         it "does not show partial view's relative path as HTML comment" do
-          should be_success
+          should be_successful
           response.body.should_not include("<!-- BEGIN app/views/examples/_example.html.erb -->")
           response.body.should_not include("<!-- END app/views/examples/_example.html.erb -->")
           response.body.should_not include("<!-- BEGIN app/views/examples/index.html.erb -->")
@@ -66,7 +68,7 @@ describe ExamplesController do
         end
 
         it "does not show partial view's relative path as HTML comment" do
-          should be_success
+          should be_successful
           response.body.should_not include("<!-- BEGIN app/views/examples/_example.text.erb -->")
           response.body.should_not include("<!-- END app/views/examples/_example.text.erb -->")
           response.body.should_not include("<!-- BEGIN app/views/examples/index.text.erb -->")
@@ -81,10 +83,10 @@ describe ExamplesController do
       ViewSourceMap.attach
     end
 
-    let(:template)   { '_example' }
-    let(:locals)     { {} }
+    let(:args) { { partial: 'example', locals: locals } }
+    let(:locals) {}
     subject do
-      described_class.new.render_to_string(template, locals: locals)
+      described_class.new.render_to_string(args)
     end
 
     context 'with no option' do

--- a/spec/dummy/app/views/examples/_example_collection_item.html.erb
+++ b/spec/dummy/app/views/examples/_example_collection_item.html.erb
@@ -1,0 +1,1 @@
+<li>this is a collection partial view for example</li>

--- a/spec/dummy/app/views/examples/index.html.erb
+++ b/spec/dummy/app/views/examples/index.html.erb
@@ -1,5 +1,6 @@
 <h1>ExamplesController#index</h1>
 
 <%= render "example" %>
+<ul> <%= render partial: "example_collection_item", collection: Array.new(10) { 'some model' }  %> </ul>
 <%= render "example_disabled", view_source_map: false %>
 <%= render partial: "example_disabled_partial", view_source_map: false %>


### PR DESCRIPTION
Support the followings:

- `TemplateRenderer#render_template` has 4 arguments.(https://github.com/rails/rails/pull/35031)
- `PartialRenderer#render` returns not `String` but `RenderedTemplate` or `RenderedCollection`.(https://github.com/rails/rails/pull/35265)
- `LookupContext#rendered_format` is deprecated.  (https://github.com/rails/rails/pull/35331) (https://github.com/rails/rails/pull/35265/files#diff-bd7d0105f7d1dfa41a0f3e033c2688e8L317-L324)

This patch supports Rails 6 but not 5, 4 and 3. Hence I think it is necessary to add conditions by Rails version, but I have no ideas for that.... Please review :bow: