### PR TITLE
Drop Rails 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 cache:
   - bundler
 rvm:
-  - 2.0.0
-  - 2.1.10
   - 2.2.10
   - 2.3.8
   - 2.4.5
@@ -12,25 +10,9 @@ rvm:
   - 2.6.0
 before_install:
   - "ruby -e 'exit RUBY_VERSION.to_f >= 2.3' && travis_retry gem update --system || travis_retry gem install rubygems-update -v '<3' && travis_retry update_rubygems"
-  - travis_retry gem install bundler -v '<2' # Ruby <2.3 and Rails 4.2 depend on bundler 1.x.
 script: bundle exec rspec
 env:
   matrix:
-    - RAILS_VERSION="~> 4.2.0"
     - RAILS_VERSION="~> 5.0.0"
     - RAILS_VERSION="~> 5.1.0"
     - RAILS_VERSION="~> 5.2.0"
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.0.0"
-    - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.1.0"
-    - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.2.0"
-    - rvm: 2.1.10
-      env: RAILS_VERSION="~> 5.0.0"
-    - rvm: 2.1.10
-      env: RAILS_VERSION="~> 5.1.0"
-    - rvm: 2.1.10
-      env: RAILS_VERSION="~> 5.2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Drop Rails 4 support.
+
 ## 0.1.5 - 2019-05-14
 
 ### Fixed

--- a/view_source_map.gemspec
+++ b/view_source_map.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
                   "a rendered partial view as HTML comment in development environment"
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 3.2"
+  s.add_dependency "rails", ">= 5"
 end


### PR DESCRIPTION
To make it easy to support Rails 5 and 6, I'll drop Rails 4 support.

Ruby 2.0 and 2.1 supports will also be dropped in this PR because Rails 5 requires Ruby 2.2.2 or newer.